### PR TITLE
Fix TypeScript type not included when installing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "README.md",
     "LICENSE.txt",
     "oauther.js",
-    "spec"
+    "spec",
+    "oauther.d.ts"
   ],
   "scripts": {
     "test": "jasmine",


### PR DESCRIPTION
Hello,

When installing this package, the TypeScript type is not included even though the file is in the repository. This PR fixes this, so when the package is downloaded, the types are also included.